### PR TITLE
Update to latest Azure Provider APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ module "lb-dcos" {
 |------|-------------|:----:|:-----:|:-----:|
 | cluster_name | Name of the DC/OS cluster | string | - | yes |
 | location | Azure Region | string | - | yes |
+| masters_instance_nic_ids | List of master instance nic ids | list | - | yes |
+| masters_ip_configuration_names | List of master instancee nic ip configuration names | list | - | yes |
+| num_masters | Specify the amount of masters. For redundancy you should have at least 3 | string | - | yes |
+| num_public_agents | Specify the amount of public agents. These agents will host marathon-lb and edgelb | string | - | yes |
 | public_agents_additional_rules | Additional list of rules for public agents. These Rules are an additon to the default rules. | string | `<list>` | no |
+| public_agents_instance_nic_ids | List of public agents instance nic ids | list | - | yes |
+| public_agents_ip_configuration_names | List of public agents instancee nic ip configuration names | list | - | yes |
 | resource_group_name | Name of the azure resource group | string | - | yes |
 | subnet_id | Subnet ID | string | - | yes |
 | tags | Add custom tags to all resources | map | `<map>` | no |

--- a/main.tf
+++ b/main.tf
@@ -36,33 +36,36 @@
  */
 
 module "masters" {
-  source              = "dcos-terraform/lb-masters/azurerm"
-  version             = "~> 0.1.0"
-  cluster_name        = "${var.cluster_name}"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
+  source                  = "dcos-terraform/lb-masters/azurerm"
+  version                 = "~> 0.1.0"
+  cluster_name            = "${var.cluster_name}"
+  location                = "${var.location}"
+  resource_group_name     = "${var.resource_group_name}"
+  master_instance_nic_ids = ["${var.masters_instance_nic_ids}"]
 
   tags = "${var.tags}"
 }
 
 module "masters-internal" {
-  source              = "dcos-terraform/lb-masters-internal/azurerm"
-  version             = "~> 0.1.0"
-  cluster_name        = "${var.cluster_name}"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-  subnet_id           = "${var.subnet_id}"
+  source                  = "dcos-terraform/lb-masters-internal/azurerm"
+  version                 = "~> 0.1.0"
+  cluster_name            = "${var.cluster_name}"
+  location                = "${var.location}"
+  resource_group_name     = "${var.resource_group_name}"
+  subnet_id               = "${var.subnet_id}"
+  master_instance_nic_ids = ["${var.masters_instance_nic_ids}"]
 
   tags = "${var.tags}"
 }
 
 module "public-agents" {
-  source              = "dcos-terraform/lb-public-agents/azurerm"
-  version             = "~> 0.1.0"
-  cluster_name        = "${var.cluster_name}"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-  additional_rules    = "${var.public_agents_additional_rules}"
+  source                  = "dcos-terraform/lb-public-agents/azurerm"
+  version                 = "~> 0.1.0"
+  cluster_name            = "${var.cluster_name}"
+  location                = "${var.location}"
+  resource_group_name     = "${var.resource_group_name}"
+  additional_rules        = "${var.public_agents_additional_rules}"
+  public_instance_nic_ids = ["${var.public_agents_instance_nic_ids}"]
 
   tags = "${var.tags}"
 }

--- a/main.tf
+++ b/main.tf
@@ -36,36 +36,42 @@
  */
 
 module "masters" {
-  source                  = "dcos-terraform/lb-masters/azurerm"
-  version                 = "~> 0.1.0"
-  cluster_name            = "${var.cluster_name}"
-  location                = "${var.location}"
-  resource_group_name     = "${var.resource_group_name}"
-  master_instance_nic_ids = ["${var.masters_instance_nic_ids}"]
+  source                 = "dcos-terraform/lb-masters/azurerm"
+  version                = "~> 0.1.0"
+  cluster_name           = "${var.cluster_name}"
+  location               = "${var.location}"
+  resource_group_name    = "${var.resource_group_name}"
+  instance_nic_ids       = ["${var.masters_instance_nic_ids}"]
+  ip_configuration_names = ["${var.masters_ip_configuration_names}"]
+  num                    = "${var.num_masters}"
 
   tags = "${var.tags}"
 }
 
 module "masters-internal" {
-  source                  = "dcos-terraform/lb-masters-internal/azurerm"
-  version                 = "~> 0.1.0"
-  cluster_name            = "${var.cluster_name}"
-  location                = "${var.location}"
-  resource_group_name     = "${var.resource_group_name}"
-  subnet_id               = "${var.subnet_id}"
-  master_instance_nic_ids = ["${var.masters_instance_nic_ids}"]
+  source                 = "dcos-terraform/lb-masters-internal/azurerm"
+  version                = "~> 0.1.0"
+  cluster_name           = "${var.cluster_name}"
+  location               = "${var.location}"
+  resource_group_name    = "${var.resource_group_name}"
+  subnet_id              = "${var.subnet_id}"
+  instance_nic_ids       = ["${var.masters_instance_nic_ids}"]
+  ip_configuration_names = ["${var.masters_ip_configuration_names}"]
+  num                    = "${var.num_masters}"
 
   tags = "${var.tags}"
 }
 
 module "public-agents" {
-  source                  = "dcos-terraform/lb-public-agents/azurerm"
-  version                 = "~> 0.1.0"
-  cluster_name            = "${var.cluster_name}"
-  location                = "${var.location}"
-  resource_group_name     = "${var.resource_group_name}"
-  additional_rules        = "${var.public_agents_additional_rules}"
-  public_instance_nic_ids = ["${var.public_agents_instance_nic_ids}"]
+  source                 = "dcos-terraform/lb-public-agents/azurerm"
+  version                = "~> 0.1.0"
+  cluster_name           = "${var.cluster_name}"
+  location               = "${var.location}"
+  resource_group_name    = "${var.resource_group_name}"
+  additional_rules       = "${var.public_agents_additional_rules}"
+  instance_nic_ids       = ["${var.public_agents_instance_nic_ids}"]
+  ip_configuration_names = ["${var.public_agents_ip_configuration_names}"]
+  num                    = "${var.num_public_agents}"
 
   tags = "${var.tags}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,27 @@ variable "public_agents_instance_nic_ids" {
   type        = "list"
 }
 
+variable "masters_ip_configuration_names" {
+  description = "List of master instancee nic ip configuration names"
+  type        = "list"
+}
+
+variable "public_agents_ip_configuration_names" {
+  description = "List of public agents instancee nic ip configuration names"
+  type        = "list"
+}
+
 variable "public_agents_additional_rules" {
   description = "Additional list of rules for public agents. These Rules are an additon to the default rules."
   default     = []
+}
+
+# Number of Masters
+variable "num_masters" {
+  description = "Specify the amount of masters. For redundancy you should have at least 3"
+}
+
+# Number of Public Agents
+variable "num_public_agents" {
+  description = "Specify the amount of public agents. These agents will host marathon-lb and edgelb"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,16 @@ variable "subnet_id" {
   description = "Subnet ID"
 }
 
+variable "masters_instance_nic_ids" {
+  description = "List of master instance nic ids"
+  type        = "list"
+}
+
+variable "public_agents_instance_nic_ids" {
+  description = "List of public agents instance nic ids"
+  type        = "list"
+}
+
 variable "public_agents_additional_rules" {
   description = "Additional list of rules for public agents. These Rules are an additon to the default rules."
   default     = []


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49945

Azure has deprecated some of their api and requires universal installer updates in order for us to continue to use these changes. Whenever there is a new resource introduced into the templates, this is considered a breaking change to our definition and requires an update to a minor version of the universal installer.

There is a limitation/workaround here that was used within these 0.2 change that will be updated when terraform v0.12.0 is released.

The issue is located here: `https://github.com/hashicorp/terraform/issues/12570`