### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,13 @@ module "masters" {
   source  = "dcos-terraform/lb-masters/azurerm"
   version = "~> 0.2.0"
 
-  cluster_name        = "${var.cluster_name}"
-  name_prefix         = "${var.name_prefix}"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-  instance_nic_ids    = ["${var.masters_instance_nic_ids}"]
-  num                 = "${var.num_masters}"
+  cluster_name                = "${var.cluster_name}"
+  name_prefix                 = "${var.name_prefix}"
+  location                    = "${var.location}"
+  resource_group_name         = "${var.resource_group_name}"
+  instance_nic_ids            = ["${var.masters_instance_nic_ids}"]
+  num                         = "${var.num_masters}"
+  adminrouter_grpc_proxy_port = "${var.adminrouter_grpc_proxy_port}"
 
   tags = "${var.tags}"
 }
@@ -53,13 +54,14 @@ module "masters-internal" {
   source  = "dcos-terraform/lb-masters-internal/azurerm"
   version = "~> 0.2.0"
 
-  cluster_name        = "${var.cluster_name}"
-  name_prefix         = "${var.name_prefix}"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-  subnet_id           = "${var.subnet_id}"
-  instance_nic_ids    = ["${var.masters_instance_nic_ids}"]
-  num                 = "${var.num_masters}"
+  cluster_name                = "${var.cluster_name}"
+  name_prefix                 = "${var.name_prefix}"
+  location                    = "${var.location}"
+  resource_group_name         = "${var.resource_group_name}"
+  subnet_id                   = "${var.subnet_id}"
+  instance_nic_ids            = ["${var.masters_instance_nic_ids}"]
+  num                         = "${var.num_masters}"
+  adminrouter_grpc_proxy_port = "${var.adminrouter_grpc_proxy_port}"
 
   tags = "${var.tags}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,8 @@ variable "num_masters" {
 variable "num_public_agents" {
   description = "Specify the amount of public agents. These agents will host marathon-lb and edgelb"
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476